### PR TITLE
Configuration of SSH Port

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -16,10 +16,10 @@ if [ -z "$PORT" ]; then
     PORT=22
 fi
 
-echo $SERVER    # 1>&2
-echo $PORT      # 1>&2
-echo $BASE_DIR  # 1>&2
-echo $USER      # 1>&2
+echo $SERVER    1>&2
+echo $PORT      1>&2
+echo $BASE_DIR  1>&2
+echo $USER      1>&2
 
 mkdir ~/.ssh
 chmod 600 ~/.ssh

--- a/assets/check
+++ b/assets/check
@@ -16,10 +16,10 @@ if [ -z "$PORT" ]; then
     PORT=22
 fi
 
-echo $SERVER  1>&2
-echo $PORT  1>&2
-echo $BASE_DIR  1>&2
-echo $USER  1>&2
+echo $SERVER    # 1>&2
+echo $PORT      # 1>&2
+echo $BASE_DIR  # 1>&2
+echo $USER      # 1>&2
 
 mkdir ~/.ssh
 chmod 600 ~/.ssh

--- a/assets/check
+++ b/assets/check
@@ -5,11 +5,19 @@ SCRIPT_INPUT='/tmp/input'
 cat > $SCRIPT_INPUT <&0 # STDIN params
 
 SERVER=$(jq -r '.source.server // ""' < $SCRIPT_INPUT)
+SERVER=$(jq -r '.source.port // ""' < $SCRIPT_INPUT)
 BASE_DIR=$(jq -r '.source.base_dir // ""' < $SCRIPT_INPUT)
 USER=$(jq -r '.source.user // ""' < $SCRIPT_INPUT)
 VERSION=$(jq -r '.version.ref // ""' < $SCRIPT_INPUT)
 
+## check if port is set in the configuration and
+## use default SSH port number 22 otherwise
+if [ -z "$PORT" ]; then
+    PORT=22
+fi
+
 echo $SERVER  1>&2
+echo $PORT  1>&2
 echo $BASE_DIR  1>&2
 echo $USER  1>&2
 
@@ -25,7 +33,7 @@ SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add ~/.ssh/server_key  1>&2  >
 echo $VERSION  1>&2
 
 REFS=''
-for DIR in `ssh -i ~/.ssh/server_key $USER@$SERVER ls -1t $BASE_DIR`; do
+for DIR in `ssh -i ~/.ssh/server_key -p $PORT $USER@$SERVER ls -1t $BASE_DIR`; do
   echo $DIR 1>&2
   echo ${#REFS} 1>&2
 

--- a/assets/check
+++ b/assets/check
@@ -5,7 +5,7 @@ SCRIPT_INPUT='/tmp/input'
 cat > $SCRIPT_INPUT <&0 # STDIN params
 
 SERVER=$(jq -r '.source.server // ""' < $SCRIPT_INPUT)
-SERVER=$(jq -r '.source.port // ""' < $SCRIPT_INPUT)
+PORT=$(jq -r '.source.port // ""' < $SCRIPT_INPUT)
 BASE_DIR=$(jq -r '.source.base_dir // ""' < $SCRIPT_INPUT)
 USER=$(jq -r '.source.user // ""' < $SCRIPT_INPUT)
 VERSION=$(jq -r '.version.ref // ""' < $SCRIPT_INPUT)

--- a/assets/in
+++ b/assets/in
@@ -20,11 +20,19 @@ SCRIPT_INPUT='/tmp/input'
 cat > $SCRIPT_INPUT <&0 # STDIN params
 
 SERVER=$(jq -r '.source.server // ""' < $SCRIPT_INPUT)
+PORT=$(jq -r '.source.port // ""' < $SCRIPT_INPUT)
 BASE_DIR=$(jq -r '.source.base_dir // ""' < $SCRIPT_INPUT)
 USER=$(jq -r '.source.user // ""' < $SCRIPT_INPUT)
 VERSION=$(jq -r '.version.ref // ""' < $SCRIPT_INPUT)
 
+## check if port is set in the configuration and
+## use default SSH port number 22 otherwise
+if [ -z "$PORT" ]; then
+    PORT=22
+fi
+
 echo $SERVER 1>&2
+echo $PORT 1>&2
 echo $BASE_DIR 1>&2
 echo $USER 1>&2
 
@@ -40,8 +48,8 @@ SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add ~/.ssh/server_key 1>&2 >/d
 SRC_DIR=$BASE_DIR/$VERSION
 echo $SRC_DIR 1>&2
 
-if (ssh -t -i ~/.ssh/server_key $USER@$SERVER '[ -d $SRC_DIR ]' ); then
-  RSYNC_CMD="rsync -Pav -e 'ssh -i ~/.ssh/server_key' $USER@$SERVER:$SRC_DIR/* $DEST_DIR"
+if (ssh -t -i ~/.ssh/server_key -p $PORT $USER@$SERVER '[ -d $SRC_DIR ]' ); then
+  RSYNC_CMD="rsync -Pav -e 'ssh -i ~/.ssh/server_key -p $PORT' $USER@$SERVER:$SRC_DIR/* $DEST_DIR"
   echo $RSYNC_CMD  1>&2
   eval $RSYNC_CMD  1>&2
   if [ $? -eq 0 ]; then

--- a/assets/in
+++ b/assets/in
@@ -31,10 +31,10 @@ if [ -z "$PORT" ]; then
     PORT=22
 fi
 
-echo $SERVER 1>&2
-echo $PORT 1>&2
-echo $BASE_DIR 1>&2
-echo $USER 1>&2
+echo $SERVER    1>&2
+echo $PORT      1>&2
+echo $BASE_DIR  1>&2
+echo $USER      1>&2
 
 mkdir ~/.ssh
 chmod 600 ~/.ssh

--- a/assets/out
+++ b/assets/out
@@ -20,12 +20,20 @@ SCRIPT_INPUT='/tmp/input'
 cat > $SCRIPT_INPUT <&0 # STDIN params
 
 SERVER=$(jq -r '.source.server // ""' < $SCRIPT_INPUT)
+PORT=$(jq -r '.source.port // ""' < $SCRIPT_INPUT)
 BASE_DIR=$(jq -r '.source.base_dir // ""' < $SCRIPT_INPUT)
 USER=$(jq -r '.source.user // ""' < $SCRIPT_INPUT)
 SYNC_DIR=$(jq -r '.params.sync_dir // ""' < $SCRIPT_INPUT)
 
+## check if port is set in the configuration and
+## use default SSH port number 22 otherwise
+if [ -z "$PORT" ]; then
+    PORT=22
+fi
+
 echo $SCRIPT_INPUT 1>&2
 echo $SERVER 1>&2
+echo $PORT 1>&2
 echo $BASE_DIR 1>&2
 echo $USER 1>&2
 echo $SYNC_DIR 1>&2
@@ -50,12 +58,12 @@ if [ $? -eq 0 ]; then
   DEST_DIR=$BASE_DIR/$MD5_STRING
   echo $DEST_DIR 1>&2
 
-  CMD="ssh -i ~/.ssh/server_key $USER@$SERVER mkdir -p $DEST_DIR"
+  CMD="ssh -i ~/.ssh/server_key -p $PORT $USER@$SERVER mkdir -p $DEST_DIR"
   echo $CMD 1>&2
   eval $CMD 1>&2
 
   if [ $? -eq 0 ]; then
-    RSYNC_CMD="rsync -Pav -e 'ssh -i ~/.ssh/server_key'  $SRC_DIR/$SYNC_DIR/* $USER@$SERVER:$DEST_DIR"
+    RSYNC_CMD="rsync -Pav -e 'ssh -i ~/.ssh/server_key -p $PORT'  $SRC_DIR/$SYNC_DIR/* $USER@$SERVER:$DEST_DIR"
     echo $RSYNC_CMD 1>&2
 
     eval $RSYNC_CMD  1>&2

--- a/assets/out
+++ b/assets/out
@@ -32,11 +32,11 @@ if [ -z "$PORT" ]; then
 fi
 
 echo $SCRIPT_INPUT 1>&2
-echo $SERVER 1>&2
-echo $PORT 1>&2
-echo $BASE_DIR 1>&2
-echo $USER 1>&2
-echo $SYNC_DIR 1>&2
+echo $SERVER       1>&2
+echo $PORT         1>&2
+echo $BASE_DIR     1>&2
+echo $USER         1>&2
+echo $SYNC_DIR     1>&2
 
 mkdir ~/.ssh
 chmod 600 ~/.ssh


### PR DESCRIPTION
Added an additional configuration field called ".source.port" to define alternative SSH port for the server connection. By omitting the definition in the configuration the setting will fallback to the standard SSH port 22.