### PR TITLE
always use mkdir -p; remove -v (causing go errors)

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -25,11 +25,10 @@ echo $BASE_DIR  1>&2
 echo $USER      1>&2
 echo $VERSION  1>&2
 
-mkdir -vp ~/.ssh
-chmod 600 ~/.ssh
+mkdir -p ~/.ssh
 (jq -r '.source.private_key // empty' < $SCRIPT_INPUT) > ~/.ssh/server_key
 echo -e "Host $SERVER\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-chmod 600 ~/.ssh/*
+chmod -R 600 ~/.ssh
 
 eval $(ssh-agent)  1>&2  >/dev/null
 SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add ~/.ssh/server_key  1>&2  >/dev/null

--- a/assets/in
+++ b/assets/in
@@ -40,11 +40,10 @@ echo $BASE_DIR  1>&2
 echo $USER      1>&2
 echo $VERSION   1>&2
 
-mkdir ~/.ssh
-chmod 600 ~/.ssh
+mkdir -p ~/.ssh
 (jq -r '.source.private_key // empty' < $SCRIPT_INPUT) > ~/.ssh/server_key
 echo -e "Host $SERVER\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-chmod 600 ~/.ssh/*
+chmod -R 600 ~/.ssh
 
 eval $(ssh-agent) 1>&2 >/dev/null
 SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add ~/.ssh/server_key 1>&2 >/dev/null

--- a/assets/out
+++ b/assets/out
@@ -49,15 +49,14 @@ echo $USER         1>&2
 echo $SYNC_DIR     1>&2
 echo "DISABLE_VERSION_PATH=$DISABLE_VERSION_PATH" 1>&2
 
-mkdir ~/.ssh
-chmod 600 ~/.ssh
+mkdir -p ~/.ssh
 (jq -r '.source.private_key // empty' < $SCRIPT_INPUT) > ~/.ssh/server_key
 for SERVER in $SERVERS
 do
     echo -e "Host $SERVER\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 done
 
-chmod 600 ~/.ssh/*
+chmod -R 600 ~/.ssh
 
 eval $(ssh-agent) 1>&2 2>/dev/null
 SSH_ASKPASS=/opt/resource/askpass.sh DISPLAY= ssh-add ~/.ssh/server_key 1>&2 2>/dev/null


### PR DESCRIPTION
Reduces the chmod to one call; removes -v from mkdir calls.

If -v is present and a folder is created, we can end up tripping up Concourse, which is expecting only JSON output on stdout.  The output from the folder creation results in an error message like 

```invalid character 'c' looking for beginning of value```

Alternatively, you could slap ``1>&2`` onto the mkdir -vp command.  Let me know if you'd prefer that.