### PR TITLE
#32: Split build-and-push into discrete CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,110 @@ jobs:
           scandir: ./assets
           severity: warning
 
-  build-and-push:
-    name: Build and Push
+  build:
+    name: Build
     runs-on: ubuntu-latest
     needs: shellcheck
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/mrsixw/concourse-rsync-resource:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  scan:
+    name: Trivy Scan
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/mrsixw/concourse-rsync-resource:${{ github.sha }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL
+          trivyignores: .trivyignore.yaml
+
+      - name: Verify Alpine version matches published
+        run: |
+          PUBLISHED=$(docker run --rm mrsixw/concourse-rsync-resource:latest cat /etc/alpine-release 2>/dev/null || echo "none")
+          BUILT=$(docker run --rm ghcr.io/mrsixw/concourse-rsync-resource:${{ github.sha }} cat /etc/alpine-release)
+          echo "Published Alpine: $PUBLISHED"
+          echo "Built Alpine:     $BUILT"
+          PUBLISHED_MINOR=$(echo "$PUBLISHED" | cut -d. -f1-2)
+          BUILT_MINOR=$(echo "$BUILT" | cut -d. -f1-2)
+          if [ "$PUBLISHED" != "none" ] && [ "$PUBLISHED_MINOR" != "$BUILT_MINOR" ]; then
+            echo "Error: Alpine minor version mismatch (published=$PUBLISHED, built=$BUILT)"
+            exit 1
+          fi
+
+  scout:
+    name: Docker Scout
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      packages: read
+      pull-requests: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker Scout CVE report
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: ghcr.io/mrsixw/concourse-rsync-resource:${{ github.sha }}
+          only-severities: critical,high
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  push:
+    name: Push to Docker Hub
+    runs-on: ubuntu-latest
+    needs: scan
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -41,36 +141,12 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
-      - name: Build image
-        uses: docker/build-push-action@v6
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          context: .
-          load: true
-          tags: mrsixw/concourse-rsync-resource:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: mrsixw/concourse-rsync-resource:${{ github.sha }}
-          format: table
-          exit-code: '1'
-          severity: CRITICAL
-          trivyignores: .trivyignore.yaml
-
-      - name: Verify Alpine version matches published
-        run: |
-          PUBLISHED=$(docker run --rm mrsixw/concourse-rsync-resource:latest cat /etc/alpine-release 2>/dev/null || echo "none")
-          BUILT=$(docker run --rm mrsixw/concourse-rsync-resource:${{ github.sha }} cat /etc/alpine-release)
-          echo "Published Alpine: $PUBLISHED"
-          echo "Built Alpine:     $BUILT"
-          PUBLISHED_MINOR=$(echo "$PUBLISHED" | cut -d. -f1-2)
-          BUILT_MINOR=$(echo "$BUILT" | cut -d. -f1-2)
-          if [ "$PUBLISHED" != "none" ] && [ "$PUBLISHED_MINOR" != "$BUILT_MINOR" ]; then
-            echo "Error: Alpine minor version mismatch (published=$PUBLISHED, built=$BUILT)"
-            exit 1
-          fi
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -78,20 +154,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker Scout CVE report
-        uses: docker/scout-action@v1
-        with:
-          command: cves
-          image: local://mrsixw/concourse-rsync-resource:${{ github.sha }}
-          only-severities: critical,high
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push to Docker Hub
-        if: github.event_name == 'push'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Copy image from GHCR to Docker Hub
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{print "-t " $0}' | tr '\n' ' ')
+          docker buildx imagetools create $TAGS ghcr.io/mrsixw/concourse-rsync-resource:${{ github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ All logic lives in three executable bash scripts under `assets/`, which Concours
 - `rsync_opts` param on `out` overrides the default `-Pav`.
 - Debug output goes to stderr; only the final JSON version string goes to stdout.
 
+## Keeping docs in sync
+
+When making changes to the CI pipeline (`.github/workflows/`), versioning behaviour, or release process, update the **CI / Releasing** section of `README.md` in the same PR to reflect the change.
+
 ## Commit messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/). The CI auto-tags on every master merge using these rules:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # concourse-rsync-resource
+
+![CI](https://github.com/mrsixw/concourse-rsync-resource/actions/workflows/ci.yml/badge.svg)
+
 [concourse.ci](https://concourse.ci/ "concourse.ci Homepage") [resource](https://concourse.ci/implementing-resources.html "Implementing a resource") for persisting build artifacts on a shared storage location with rsync and ssh.
 
 ## Config
@@ -70,3 +73,23 @@ using the specified user credential. Rsync across artifacts from the input direc
 #### Parameters
 
 * `sync_dir`: *Optional.* Directory to be sync'd. If specified limit the directory to be sync'd to sync_dir. If not specified everything in the `put` will be sent (which could include container resources, whole build trees etc.)
+
+## CI / Releasing
+
+Every push to `master` and all pull requests run the CI pipeline:
+
+1. **Shellcheck** — lints all `assets/` bash scripts
+2. **Build** — builds the Docker image and pushes to GHCR as a staging registry
+3. **Trivy scan** — checks for CRITICAL CVEs (parallel with Scout)
+4. **Docker Scout** — posts a CVE breakdown as a PR comment (parallel with Trivy)
+5. **Push** — copies the image from GHCR to Docker Hub (master and tags only)
+
+Releases are versioned automatically using [Conventional Commits](https://www.conventionalcommits.org/). On every merge to `master` a new tag is created and the image is published to Docker Hub with full semver tags (`1.2.3`, `1.2`, `1`, `latest`).
+
+| Commit prefix | Version bump |
+|---|---|
+| `feat:` | minor |
+| `fix:`, `ci:`, `chore:`, etc. | patch |
+| `feat!:` / `BREAKING CHANGE:` | major |
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.

--- a/README.md
+++ b/README.md
@@ -76,20 +76,35 @@ using the specified user credential. Rsync across artifacts from the input direc
 
 ## CI / Releasing
 
-Every push to `master` and all pull requests run the CI pipeline:
+Every push to `master` and all pull requests run the CI pipeline, defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
-1. **Shellcheck** — lints all `assets/` bash scripts
-2. **Build** — builds the Docker image and pushes to GHCR as a staging registry
-3. **Trivy scan** — checks for CRITICAL CVEs (parallel with Scout)
-4. **Docker Scout** — posts a CVE breakdown as a PR comment (parallel with Trivy)
-5. **Push** — copies the image from GHCR to Docker Hub (master and tags only)
+### Pipeline jobs
 
-Releases are versioned automatically using [Conventional Commits](https://www.conventionalcommits.org/). On every merge to `master` a new tag is created and the image is published to Docker Hub with full semver tags (`1.2.3`, `1.2`, `1`, `latest`).
+```
+shellcheck → build → scan  ─┐
+                   → scout  ├→ push (master / tags only)
+```
 
-| Commit prefix | Version bump |
-|---|---|
-| `feat:` | minor |
-| `fix:`, `ci:`, `chore:`, etc. | patch |
-| `feat!:` / `BREAKING CHANGE:` | major |
+**Shellcheck** lints all bash scripts in `assets/` using [shellcheck](https://www.shellcheck.net/) before anything is built.
+
+**Build** compiles the Docker image and pushes it to [GitHub Container Registry (GHCR)](https://ghcr.io) using the commit SHA as the tag. GHCR acts as a staging registry so subsequent jobs can pull the already-built image rather than rebuilding it.
+
+**Scan** (runs in parallel with Scout) pulls the image from GHCR and runs two checks:
+- [Trivy](https://trivy.dev/) scans for CRITICAL CVEs and fails the build if any are found that aren't listed in `.trivyignore.yaml`. Currently suppressed CVEs are all due to the Alpine 3.7 EOL base image and are tracked for resolution in [#30](https://github.com/mrsixw/concourse-rsync-resource/issues/30).
+- An Alpine version check ensures the base image minor version (`3.x`) matches the currently published image on Docker Hub, catching accidental base image upgrades.
+
+**Scout** (runs in parallel with Scan) runs [Docker Scout](https://docs.docker.com/scout/) against the GHCR image and posts a CRITICAL/HIGH CVE breakdown as a comment on the PR. Scout failures are informational and do not block the push.
+
+**Push** only runs on pushes to `master` or version tags. It copies the image directly from GHCR to Docker Hub using `docker buildx imagetools create` — a registry-to-registry manifest copy with no rebuild. The image is published with full semver tags.
+
+### Versioning
+
+Releases are versioned automatically using [Conventional Commits](https://www.conventionalcommits.org/). On every merge to `master`, [`.github/workflows/tag.yml`](.github/workflows/tag.yml) creates a new git tag which then triggers the push job to publish a versioned image to Docker Hub.
+
+| Commit prefix | Version bump | Docker Hub tags published |
+|---|---|---|
+| `feat:` | minor | `1.2.0`, `1.2`, `1`, `latest` |
+| `fix:`, `ci:`, `chore:`, etc. | patch | `1.1.1`, `1.1`, `1`, `latest` |
+| `feat!:` / `BREAKING CHANGE:` | major | `2.0.0`, `2.0`, `2`, `latest` |
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.


### PR DESCRIPTION
## Summary

- **build** — builds the image and pushes to GHCR as an intermediate registry
- **scan** — pulls from GHCR, runs Trivy CVE scan and Alpine version check
- **scout** — pulls from GHCR, posts Docker Scout CVE report as PR comment (runs in parallel with scan)
- **push** — copies image from GHCR to Docker Hub using `imagetools create` (no rebuild); master/tag only, gated on scan passing

Using GHCR as the intermediate avoids rebuilding the image in every job — subsequent jobs just pull the already-built image.

## Test plan

- [ ] Verify build job pushes to GHCR successfully
- [ ] Verify scan and scout run in parallel after build
- [ ] Verify push is skipped on this PR (master/tag only)
- [ ] After merge, verify push job copies correct tags to Docker Hub

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)