### PR TITLE
#31: Replace deprecated MAINTAINER with OCI label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.7
-MAINTAINER Steve Williams <mrsixw@gmail.com>
+LABEL org.opencontainers.image.authors="Steve Williams <mrsixw@gmail.com>"
 
 RUN apk update && apk upgrade && \
     apk add --update  bash rsync jq openssh


### PR DESCRIPTION
Replaces the deprecated `MAINTAINER` instruction with the OCI standard label.

## Change

```dockerfile
# before
MAINTAINER Steve Williams <mrsixw@gmail.com>

# after
LABEL org.opencontainers.image.authors="Steve Williams <mrsixw@gmail.com>"
```

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)