### PR TITLE
fix: tag workflow fires once per PR merge not per commit

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,13 +1,15 @@
 name: Tag
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [master]
 
 jobs:
   tag:
     name: Create version tag
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     permissions:
       contents: write
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ All logic lives in three executable bash scripts under `assets/`, which Concours
 - `rsync_opts` param on `out` overrides the default `-Pav`.
 - Debug output goes to stderr; only the final JSON version string goes to stdout.
 
+## Issues and PRs
+
+Always raise a GitHub issue before opening a PR. The PR description must reference the issue with `Closes #N`. This applies even for small fixes spotted during other work — create the issue first, then the PR.
+
 ## Keeping docs in sync
 
 When making changes to the CI pipeline (`.github/workflows/`), versioning behaviour, or release process, update the **CI / Releasing** section of `README.md` in the same PR to reflect the change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ All logic lives in three executable bash scripts under `assets/`, which Concours
 
 ## Issues and PRs
 
-Always raise a GitHub issue before opening a PR. The PR description must reference the issue with `Closes #N`. This applies even for small fixes spotted during other work — create the issue first, then the PR.
+Every PR must reference a GitHub issue with `Closes #N`. If one doesn't already exist, raise it first. If the work was triggered by an existing issue, use that — don't create a duplicate.
 
 ## Keeping docs in sync
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ shellcheck → build → scan  ─┐
 
 ### Versioning
 
-Releases are versioned automatically using [Conventional Commits](https://www.conventionalcommits.org/). On every merge to `master`, [`.github/workflows/tag.yml`](.github/workflows/tag.yml) creates a new git tag which then triggers the push job to publish a versioned image to Docker Hub.
+Releases are versioned automatically using [Conventional Commits](https://www.conventionalcommits.org/). When a PR is merged to `master`, [`.github/workflows/tag.yml`](.github/workflows/tag.yml) creates a single git tag (regardless of how many commits the PR contained), which then triggers the push job to publish a versioned image to Docker Hub.
 
 | Commit prefix | Version bump | Docker Hub tags published |
 |---|---|---|


### PR DESCRIPTION
## Problem

The tag workflow triggered on every `push` to master. A PR with multiple commits caused it to fire once per commit, creating multiple tags per merge.

## Fix

Change the trigger from `push: branches: [master]` to `pull_request: types: [closed]` with a `merged == true` guard. This fires exactly once when a PR is merged, regardless of commit count.

## Test plan
- [ ] Merge a multi-commit PR and confirm only one new tag is created

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)